### PR TITLE
readme: add url example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Label which will be presented at the top
 
 ### URL 
 
-This is your Jira server URL. Copy entire url, with protocol and port (if not default).
+This is your Jira server URL. Copy entire url, with protocol and port (if not default). Example: `https://jira.example.net/`.
 
 ### REST Api Extension
 


### PR DESCRIPTION
for me it's always confusing, do it write `https://jira.example.net` or `https://jira.example.net/`

regardless the value, i still get 404 in status window:

![image](https://user-images.githubusercontent.com/199095/45940808-c184fe00-bfe3-11e8-86d7-bb8bd22b8d3c.png)
